### PR TITLE
Improve auth logging

### DIFF
--- a/device/android.py
+++ b/device/android.py
@@ -48,7 +48,13 @@ class Android(Device):
         return xmltodict.unparse(syncml_data, pretty=False)
 
     def get_enrollment_token(self, refresh_token):
-        return renew_token(refresh_token, '9ba1a5c7-f17a-4de9-a1f1-6178c8d51223', 'openid offline_access profile d4ebce55-015a-49b5-a083-c84d1797ae8c/.default', self.proxy)
+        return renew_token(
+            refresh_token,
+            '9ba1a5c7-f17a-4de9-a1f1-6178c8d51223',
+            'openid offline_access profile d4ebce55-015a-49b5-a083-c84d1797ae8c/.default',
+            self.proxy,
+            self.logger,
+        )
 
     def send_enroll_request(self, enrollment_url, csr_pem, csr_token, ztdregistrationid):
         token_b64 = base64.b64encode(csr_token.encode('utf-8')).decode('utf-8')

--- a/device/device.py
+++ b/device/device.py
@@ -55,6 +55,9 @@ class Device:
             auth.resource_uri = devicereg
             auth.proxies = self.proxy
             auth.verify = False
+            self.logger.info(
+                f"performing username/password auth for '{username}' to resource '{devicereg}'"
+            )
             access_token = auth.authenticate_username_password()['accessToken']
 
         certpath = f'{self.device_name}_cert.pem'
@@ -303,8 +306,16 @@ class Device:
         self.logger.info(f"resolved IWservice url: {iwservice_url}")
         token_renewal_url = self.get_enrollment_info(access_token, 'TokenRenewalService')
         self.logger.info(f"resolved token renewal url: {token_renewal_url}")
-        renewal_token = renew_token(refresh_token, '9ba1a5c7-f17a-4de9-a1f1-6178c8d51223', 'd4ebce55-015a-49b5-a083-c84d1797ae8c/.default openid offline_access profile', self.proxy)
-        enrollment_token = token_renewal_for_enrollment(token_renewal_url, renewal_token, self.proxy)
+        renewal_token = renew_token(
+            refresh_token,
+            '9ba1a5c7-f17a-4de9-a1f1-6178c8d51223',
+            'd4ebce55-015a-49b5-a083-c84d1797ae8c/.default openid offline_access profile',
+            self.proxy,
+            self.logger,
+        )
+        enrollment_token = token_renewal_for_enrollment(
+            token_renewal_url, renewal_token, self.proxy, self.logger
+        )
 
         device_name = self.get_device_info(iwservice_url, enrollment_token, 'OfficialName')
         state = self.get_device_info(iwservice_url, enrollment_token, 'ComplianceState')
@@ -337,8 +348,16 @@ class Device:
         token_renewal_url = self.get_enrollment_info(access_token, 'TokenRenewalService')
         self.logger.info(f"resolved token renewal url: {token_renewal_url}")
 
-        renewal_token = renew_token(refresh_token, '9ba1a5c7-f17a-4de9-a1f1-6178c8d51223', 'd4ebce55-015a-49b5-a083-c84d1797ae8c/.default openid offline_access profile', self.proxy)
-        enrollment_token = token_renewal_for_enrollment(token_renewal_url, renewal_token, self.proxy)
+        renewal_token = renew_token(
+            refresh_token,
+            '9ba1a5c7-f17a-4de9-a1f1-6178c8d51223',
+            'd4ebce55-015a-49b5-a083-c84d1797ae8c/.default openid offline_access profile',
+            self.proxy,
+            self.logger,
+        )
+        enrollment_token = token_renewal_for_enrollment(
+            token_renewal_url, renewal_token, self.proxy, self.logger
+        )
 
         retire_info = self.get_device_info(iwservice_url, enrollment_token, '#CommonContainer.Retire')
         if retire_info == None:
@@ -349,7 +368,7 @@ class Device:
             return
 
         retire_url = retire_info['target']
-        self.logger.info(f"resolved reitrement url: {retire_url}")
+        self.logger.info(f"resolved retirement url: {retire_url}")
 
         result = self.send_retire_request(retire_url, enrollment_token)
         if result == True:

--- a/device/linux.py
+++ b/device/linux.py
@@ -18,7 +18,13 @@ class Linux(Device):
         self.cname = self.device_name
 
     def get_enrollment_token(self, refresh_token):
-        return renew_token(refresh_token, '9ba1a5c7-f17a-4de9-a1f1-6178c8d51223', 'openid offline_access profile d4ebce55-015a-49b5-a083-c84d1797ae8c/.default', self.proxy)
+        return renew_token(
+            refresh_token,
+            '9ba1a5c7-f17a-4de9-a1f1-6178c8d51223',
+            'openid offline_access profile d4ebce55-015a-49b5-a083-c84d1797ae8c/.default',
+            self.proxy,
+            self.logger,
+        )
 
     def send_enroll_request(self, enrollment_url, csr_pem, csr_token, ztdregistrationid):
         data = {
@@ -119,7 +125,13 @@ class Linux(Device):
         self.checkin_url = self.get_enrollment_info(access_token, 'LinuxDeviceCheckinService')
         self.logger.info(f"resolved checkin url: {self.checkin_url}")
 
-        access_token = renew_token(refresh_token, '9ba1a5c7-f17a-4de9-a1f1-6178c8d51223', '0000000a-0000-0000-c000-000000000000/.default openid offline_access profile')
+        access_token = renew_token(
+            refresh_token,
+            '9ba1a5c7-f17a-4de9-a1f1-6178c8d51223',
+            '0000000a-0000-0000-c000-000000000000/.default openid offline_access profile',
+            self.proxy,
+            self.logger,
+        )
 
         certpath = 'pytune_mdm.crt'
         keypath = 'pytune_mdm.key'

--- a/device/windows.py
+++ b/device/windows.py
@@ -559,7 +559,7 @@ class IME():
     def request_policy(self):
         sidecar_url = self.resolve_service_address()
         if sidecar_url is None:
-            self.logger.error('SidecCarGatewayService not found')
+            self.logger.error('SideCarGatewayService not found')
             return []
 
         sessionid = str(uuid.uuid4())

--- a/pytune.py
+++ b/pytune.py
@@ -64,7 +64,9 @@ class Pytune:
             if prt is None or session_key is None:
                 if refresh_token is None:
                     password = self.get_password(password)
-                prt, session_key = deviceauth(username, password, refresh_token, certpfx, proxy)
+                prt, session_key = deviceauth(
+                    username, password, refresh_token, certpfx, proxy, self.logger
+                )
 
             access_token, refresh_token = prtauth(prt, session_key, '29d9ed98-a469-4536-ade2-f981bc1d605e', 'https://enrollment.manage.microsoft.com/', 'ms-appx-web://Microsoft.AAD.BrokerPlugin/DRS', proxy, self.logger)
             claims = jwt.decode(access_token, options={"verify_signature": False}, algorithms=['RS256'])

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -42,7 +42,9 @@ def get_tenantid(domain):
     return token_endpoint.split('/')[3]
 
 
-def get_devicetoken(tenant, certpfx):
+def get_devicetoken(tenant, certpfx, logger=None):
+    if logger:
+        logger.info(f"requesting device token for tenant '{tenant}'")
     nonce = get_nonce()
     tid = get_tenantid(tenant)
 
@@ -86,13 +88,20 @@ def get_devicetoken(tenant, certpfx):
     return res.json()['access_token']
 
 
-def gettokens(username, password, clientid, resource):
+def gettokens(username, password, clientid, resource, logger=None):
+    if logger:
+        logger.info(
+            f"performing username/password auth for '{username}' using client_id='{clientid}' and resource='{resource}'"
+        )
     auth = Authentication(username, password, None, clientid)
     auth.resource_uri = resource
     return auth.authenticate_username_password()
 
 
-def deviceauth(username, password, refresh_token, certpfx, proxy):
+def deviceauth(username, password, refresh_token, certpfx, proxy, logger=None):
+    if logger:
+        method = "password" if password else "refresh token"
+        logger.info(f"performing DEVICEAUTH for user '{username}' using {method}")
     device_auth = DeviceAuthentication()
     device_auth.proxies = proxy
     device_auth.verify = False
@@ -137,7 +146,12 @@ def prtauth(prt, session_key, client_id, resource, redirect_uri, proxy, logger):
     return res['access_token'], res['refresh_token']
 
 
-def renew_token(refresh_token, client_id, scope, proxy):
+def renew_token(refresh_token, client_id, scope, proxy, logger=None):
+    if logger:
+        client_name = get_client_name_by_guid(client_id)
+        logger.info(
+            f"renewing token using client_id='{client_id}' ({client_name}) with scope='{scope}'"
+        )
     data = {
         'client_id': client_id,
         'grant_type': 'refresh_token',
@@ -155,7 +169,9 @@ def renew_token(refresh_token, client_id, scope, proxy):
     return json['access_token']
 
 
-def token_renewal_for_enrollment(url, access_token, proxy):
+def token_renewal_for_enrollment(url, access_token, proxy, logger=None):
+    if logger:
+        logger.info(f"retrieving enrollment token from '{url}'")
     headers = {'Authorization': 'Bearer {}'.format(access_token)}
 
     response = requests.get(


### PR DESCRIPTION
## Summary
- log client/resource/redirect info for every auth helper
- propagate logger to deviceauth and token renewal helpers
- fix typos in log messages

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684173d72cfc832aa3ee7701af88005b