### PR TITLE
Fix parser variable and proxy verification

### DIFF
--- a/device/android.py
+++ b/device/android.py
@@ -352,10 +352,6 @@ class Android(Device):
                 "Format": "chr",
                 "Data": self.deviceid
             },
-            f"./User/{self.uid}/Vendor/MSFT/Scheduler/intervalDurationSeconds": {
-                "Format": "int",
-                "Data": "28800"
-            },
             f"./Device/Vendor/MSFT/DeviceLock/DevicePolicyManager/IsActivePasswordSufficient": {
                 "Format": "bool",
                 "Data": "true"

--- a/device/device.py
+++ b/device/device.py
@@ -230,6 +230,8 @@ class Device:
         response = requests.get(
             url=msi_url,
             cert=(certpath, keypath),
+            proxies=self.proxy,
+            verify=False,
         )
 
         if response.status_code == 200 and file_name_hash:

--- a/device/linux.py
+++ b/device/linux.py
@@ -63,6 +63,8 @@ class Linux(Device):
             url=f'{self.checkin_url}/details?api-version=1.0',
             json=data,
             headers={'Authorization': f'Bearer {access_token}'},
+            proxies=self.proxy,
+            verify=False,
         )
 
         if 'deviceFriendlyName' not in response.json():
@@ -73,6 +75,8 @@ class Linux(Device):
         response = requests.get(
             url=f'{self.checkin_url}/policies/{self.intune_deviceid}?api-version=1.0',
             headers={'Authorization': 'Bearer {}'.format(access_token)},
+            proxies=self.proxy,
+            verify=False,
         )
 
         return response.json()['policies']
@@ -109,6 +113,8 @@ class Linux(Device):
             url=f'{self.checkin_url}/status?api-version=1.0',
             json=data,
             headers={'Authorization': 'Bearer {}'.format(access_token)},
+            proxies=self.proxy,
+            verify=False,
         )
         return
 

--- a/device/windows.py
+++ b/device/windows.py
@@ -479,6 +479,8 @@ class IME():
         response = requests.get(
             url='https://manage.microsoft.com/RestUserAuthLocationService/RestUserAuthLocationService/Certificate/ServiceAddresses',
             cert=(self.certpath, self.keypath),
+            verify=False,
+            proxies=self.proxy,
             )
         
         services = response.json()[0]["Services"]
@@ -525,6 +527,8 @@ class IME():
             cert=(self.certpath, self.keypath),
             data=json.dumps(data),
             headers=headers,
+            verify=False,
+            proxies=self.proxy,
             )
         
         response_payload = response.json()['ResponsePayload']
@@ -547,6 +551,8 @@ class IME():
             cert=(self.certpath, self.keypath),
             data=json.dumps(data),
             headers=headers,
+            verify=False,
+            proxies=self.proxy,
             )
         
         response_payload = response.json()['ResponsePayload']
@@ -592,14 +598,18 @@ class IME():
             cert=(self.certpath, self.keypath),
             data=json.dumps(data),
             headers=headers,
-            )    
+            verify=False,
+            proxies=self.proxy,
+            )
 
         response_payload = response.json()["ResponsePayload"]
         return json.loads(response_payload)
 
     def download_decrypt_intunewin(self, appname, upload_location, key, iv):
         response = requests.get(
-            url=upload_location
+            url=upload_location,
+            verify=False,
+            proxies=self.proxy,
         )
 
         decrypted_data = aes_decrypt(key, iv, response.content[48:])
@@ -624,6 +634,8 @@ class IME():
             cert=(self.certpath, self.keypath),
             data=json.dumps(data),
             headers=headers,
-            )    
+            verify=False,
+            proxies=self.proxy,
+            )
         response_payload = response.json()["ResponsePayload"]
         return json.loads(response_payload)

--- a/pytune.py
+++ b/pytune.py
@@ -176,9 +176,9 @@ def main():
     download_apps_intune_parser.add_argument('-m', '--mdmpfx', required=True, action='store', help='mdm pfx path')
     download_apps_intune_parser.add_argument('-d', '--device_name', required=True, action='store', help='device name')
 
-    download_apps_intune_parser = subparsers.add_parser('get_remediations', help='download available remediation scripts (only Windows supported since I\'m lazy)')
-    download_apps_intune_parser.add_argument('-m', '--mdmpfx', required=True, action='store', help='mdm pfx path')
-    download_apps_intune_parser.add_argument('-d', '--device_name', required=True, action='store', help='device name')
+    download_remediations_intune_parser = subparsers.add_parser('get_remediations', help='download available remediation scripts (only Windows supported since I\'m lazy)')
+    download_remediations_intune_parser.add_argument('-m', '--mdmpfx', required=True, action='store', help='mdm pfx path')
+    download_remediations_intune_parser.add_argument('-d', '--device_name', required=True, action='store', help='device name')
 
     args = parser.parse_args()
     proxy = None


### PR DESCRIPTION
## Summary
- remove lowercase duplicate for interval duration in Android profile
- allow MSI download to work with proxies
- skip TLS verification for proxy-based Windows and Linux requests
- split `download_apps_intune_parser` variable into separate parsers

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6841adfccf84832a92b489aba675eee6