### PR TITLE
Add Intune enumeration and intunewin extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This tools gives red teamers following advantages;
 
 ```
 python3 pytune.py -h
-usage: pytune.py [-h] {entra_join,entra_delete,enroll_intune,checkin,retire_intune,check_compliant,download_apps} ...
+usage: pytune.py [-h] {entra_join,entra_delete,enroll_intune,checkin,retire_intune,check_compliant,download_apps,get_remediations,list_policies,list_groups} ...
 
 
  ______   __  __     ______   __  __     __   __     ______    
@@ -35,7 +35,7 @@ usage: pytune.py [-h] {entra_join,entra_delete,enroll_intune,checkin,retire_intu
  \ \_\    \/\_____\    \ \_\  \ \_____\  \ \_\\"\_\  \ \_____\ 
   \/_/     \/_____/     \/_/   \/_____/   \/_/ \/_/   \/_____/ 
                                                                
-      Faking a device to Microsft Intune (version:1.0)
+      Faking a device to Microsft Intune (version:1.1)
 
 
 options:
@@ -44,7 +44,7 @@ options:
 subcommands:
   pytune commands
 
-  {entra_join,entra_delete,enroll_intune,checkin,retire_intune,check_compliant,download_apps}
+  {entra_join,entra_delete,enroll_intune,checkin,retire_intune,check_compliant,download_apps,get_remediations,list_policies,list_groups}
     entra_join          join device to Entra ID
     entra_delete        delete device from Entra ID
     enroll_intune       enroll device to Intune
@@ -52,6 +52,9 @@ subcommands:
     retire_intune       retire device from Intune
     check_compliant     check compliant status
     download_apps       download available win32apps and scripts (only Windows supported since I'm lazy)
+    get_remediations    download available remediation scripts (only Windows supported since I'm lazy)
+    list_policies       enumerate Intune policies
+    list_groups         enumerate device groups
 ```
 
 ### Enroll a fake device
@@ -207,9 +210,17 @@ Add-LocalGroupMember -Group "Administrators" -Member $userName
 [+] successfully downloaded to DomainJoin.bat.intunewin!
 ```
 
-When successful, PowerShell scripts are displayed and also .intunewin files are downloaded.
+When successful, PowerShell scripts are displayed and `.intunewin` files are downloaded.
+Each package is automatically extracted to a folder named `<app>_extracted` so the wrapped installers can be examined immediately.
 
-.intunewin file is just a zip file and you can unzip it to extract the Win32 apps inside. 
+### Enumerate Intune policies and device groups
+
+Use `list_policies` to enumerate compliance and configuration policies and `list_groups` to display Azure AD groups that can target devices.
+
+```
+$ python3 pytune.py list_policies -o Windows -c Windows_pytune.pfx -u testuser@contoso.onmicrosoft.com -p ********
+$ python3 pytune.py list_groups -o Windows -c Windows_pytune.pfx -u testuser@contoso.onmicrosoft.com -p ********
+```
 
 ### Clean-up
 

--- a/device/device.py
+++ b/device/device.py
@@ -341,6 +341,67 @@ class Device:
 
         return
 
+    def list_policies(self):
+        access_token, _ = prtauth(
+            self.prt,
+            self.session_key,
+            '9ba1a5c7-f17a-4de9-a1f1-6178c8d51223',
+            'https://graph.microsoft.com/',
+            None,
+            self.proxy,
+            self.logger,
+        )
+
+        endpoints = [
+            'deviceManagement/deviceCompliancePolicies',
+            'deviceManagement/deviceConfigurations'
+        ]
+
+        for endpoint in endpoints:
+            url = f'https://graph.microsoft.com/v1.0/{endpoint}'
+            response = requests.get(url, headers={'Authorization': f'Bearer {access_token}'}, proxies=self.proxy, verify=False)
+            if response.status_code != 200:
+                self.logger.error(f'failed to retrieve {endpoint}')
+                continue
+            items = response.json().get('value', [])
+            if len(items) == 0:
+                self.logger.info(f'no entries found for {endpoint}')
+                continue
+            self.logger.alert(f'{endpoint} :')
+            for item in items:
+                name = item.get('displayName') or item.get('name')
+                pid = item.get('id')
+                print(f' - {name} ({pid})')
+
+        return
+
+    def list_device_groups(self):
+        access_token, _ = prtauth(
+            self.prt,
+            self.session_key,
+            '9ba1a5c7-f17a-4de9-a1f1-6178c8d51223',
+            'https://graph.microsoft.com/',
+            None,
+            self.proxy,
+            self.logger,
+        )
+
+        url = 'https://graph.microsoft.com/v1.0/groups?$select=id,displayName,groupTypes'
+        response = requests.get(url, headers={'Authorization': f'Bearer {access_token}'}, proxies=self.proxy, verify=False)
+        if response.status_code != 200:
+            self.logger.error('failed to retrieve groups')
+            return
+
+        groups = response.json().get('value', [])
+        if len(groups) == 0:
+            self.logger.info('no groups found')
+            return
+        self.logger.alert('device groups:')
+        for grp in groups:
+            print(f" - {grp.get('displayName')} ({grp.get('id')}) {grp.get('groupTypes')}")
+
+        return
+
     def retire_intune(self):
         access_token, refresh_token = prtauth(self.prt, self.session_key, '9ba1a5c7-f17a-4de9-a1f1-6178c8d51223', 'https://graph.microsoft.com/', None, self.proxy, self.logger)
         iwservice_url = self.get_enrollment_info(access_token, 'IWService')

--- a/device/windows.py
+++ b/device/windows.py
@@ -603,8 +603,18 @@ class IME():
         )
 
         decrypted_data = aes_decrypt(key, iv, response.content[48:])
-        with open(f'{appname}.intunewin', 'wb') as f:
-            f.write(decrypted_data)        
+        intunewin_path = f'{appname}.intunewin'
+        with open(intunewin_path, 'wb') as f:
+            f.write(decrypted_data)
+
+        try:
+            import zipfile
+            extract_dir = f'{appname}_extracted'
+            with zipfile.ZipFile(intunewin_path, 'r') as zf:
+                zf.extractall(extract_dir)
+            self.logger.success(f'extracted to {extract_dir}')
+        except Exception as e:
+            self.logger.error(f'failed to extract {intunewin_path}: {e}')
 
     def request_policy(self):
         sidecar_url = self.resolve_service_address()

--- a/pytune.py
+++ b/pytune.py
@@ -123,6 +123,14 @@ class Pytune:
         device = self.new_device('Windows', device_name, None, None, None, None, proxy)
         device.download_remediation_scripts(mdmpfx)
 
+    def list_policies(self, operatingsystem, username, password, refresh_token, certpfx, proxy):
+        device = self.new_device(operatingsystem, None, username, password, refresh_token, certpfx, proxy)
+        device.list_policies()
+
+    def list_groups(self, operatingsystem, username, password, refresh_token, certpfx, proxy):
+        device = self.new_device(operatingsystem, None, username, password, refresh_token, certpfx, proxy)
+        device.list_device_groups()
+
 def main():
     description = f"{banner}"
     parser = argparse.ArgumentParser(add_help=True, description=color(description, fore='deepskyblue'), formatter_class=argparse.RawDescriptionHelpFormatter)
@@ -180,6 +188,20 @@ def main():
     download_apps_intune_parser.add_argument('-m', '--mdmpfx', required=True, action='store', help='mdm pfx path')
     download_apps_intune_parser.add_argument('-d', '--device_name', required=True, action='store', help='device name')
 
+    list_policies_parser = subparsers.add_parser('list_policies', help='enumerate Intune policies')
+    list_policies_parser.add_argument('-u', '--username', action='store', help='username')
+    list_policies_parser.add_argument('-p', '--password', action='store', help='password')
+    list_policies_parser.add_argument('-r', '--refresh_token', action='store', help='refresh token for device registration service')
+    list_policies_parser.add_argument('-c', '--certpfx', required=True, action='store', help='device cert pfx path')
+    list_policies_parser.add_argument('-o', '--os', required=True, action='store', help='os')
+
+    list_groups_parser = subparsers.add_parser('list_groups', help='enumerate device groups')
+    list_groups_parser.add_argument('-u', '--username', action='store', help='username')
+    list_groups_parser.add_argument('-p', '--password', action='store', help='password')
+    list_groups_parser.add_argument('-r', '--refresh_token', action='store', help='refresh token for device registration service')
+    list_groups_parser.add_argument('-c', '--certpfx', required=True, action='store', help='device cert pfx path')
+    list_groups_parser.add_argument('-o', '--os', required=True, action='store', help='os')
+
     args = parser.parse_args()
     proxy = None
     if args.proxy:
@@ -207,6 +229,10 @@ def main():
         pytune.download_apps(args.device_name, args.mdmpfx, proxy)
     if args.command == 'get_remediations':
         pytune.download_remediation_scripts(args.device_name, args.mdmpfx, proxy)
+    if args.command == 'list_policies':
+        pytune.list_policies(args.os, args.username, args.password, args.refresh_token, args.certpfx, proxy)
+    if args.command == 'list_groups':
+        pytune.list_groups(args.os, args.username, args.password, args.refresh_token, args.certpfx, proxy)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- enumerate Intune policies and device groups
- automatically extract downloaded .intunewin packages
- document the new commands and behavior in README

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841ae750798832aba393f2701edd7ce