### PR TITLE
Add pem2pfx command

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This tools gives red teamers following advantages;
 
 ```
 python3 pytune.py -h
-usage: pytune.py [-h] {entra_join,entra_delete,enroll_intune,checkin,retire_intune,check_compliant,download_apps} ...
+usage: pytune.py [-h] {entra_join,entra_delete,enroll_intune,checkin,retire_intune,check_compliant,download_apps,pem2pfx} ...
 
 
  ______   __  __     ______   __  __     __   __     ______    
@@ -44,7 +44,7 @@ options:
 subcommands:
   pytune commands
 
-  {entra_join,entra_delete,enroll_intune,checkin,retire_intune,check_compliant,download_apps}
+  {entra_join,entra_delete,enroll_intune,checkin,retire_intune,check_compliant,download_apps,pem2pfx}
     entra_join          join device to Entra ID
     entra_delete        delete device from Entra ID
     enroll_intune       enroll device to Intune
@@ -52,6 +52,7 @@ subcommands:
     retire_intune       retire device from Intune
     check_compliant     check compliant status
     download_apps       download available win32apps and scripts (only Windows supported since I'm lazy)
+    pem2pfx             convert PEM files to PFX for use with other commands
 ```
 
 ### Enroll a fake device
@@ -186,7 +187,7 @@ If there are Win32 apps or PowerShell scripts to be delviered, you can donwload 
 Here is the example of the command.
 
 ```
-$ python3 pytune.py download_apps -d Windows_pytune -m Windows_pytune_mdm.pfx                                                                            
+$ python3 pytune.py download_apps -d Windows_pytune -m Windows_pytune_mdm.pfx
 [*] downloading scripts...
 [!] scripts found!
 [*] #1 (policyid:f7e2c3b6-b57f-43fb-a17f-2feab218806b):
@@ -209,7 +210,19 @@ Add-LocalGroupMember -Group "Administrators" -Member $userName
 
 When successful, PowerShell scripts are displayed and also .intunewin files are downloaded.
 
-.intunewin file is just a zip file and you can unzip it to extract the Win32 apps inside. 
+.intunewin file is just a zip file and you can unzip it to extract the Win32 apps inside.
+
+### Convert PEM and key to PFX
+
+If you used roadtx to register a device, it outputs separate certificate and key files. Convert them to a password protected PFX with `pem2pfx`.
+
+```
+$ python3 pytune.py pem2pfx -c device_cert.pem -k device_key.pem -o device.pfx
+[+] successfully created device.pfx
+[*] password is 'password'
+```
+
+.intunewin file is just a zip file and you can unzip it to extract the Win32 apps inside.
 
 ### Clean-up
 

--- a/pytune.py
+++ b/pytune.py
@@ -8,10 +8,10 @@ from device.device import Device
 from device.android import Android
 from device.windows import Windows
 from device.linux import Linux
-from utils.utils import deviceauth, prtauth
+from utils.utils import deviceauth, prtauth, create_pfx
 from utils.logger import Logger
 
-version = '1.1'
+version = '1.2'
 banner = r'''
  ______   __  __     ______   __  __     __   __     ______    
 /\  == \ /\ \_\ \   /\__  _\ /\ \/\ \   /\ "-.\ \   /\  ___\   
@@ -123,6 +123,11 @@ class Pytune:
         device = self.new_device('Windows', device_name, None, None, None, None, proxy)
         device.download_remediation_scripts(mdmpfx)
 
+    def pem2pfx(self, certpem, keypem, pfxpath):
+        create_pfx(certpem, keypem, pfxpath)
+        self.logger.success(f"successfully created {pfxpath}")
+        self.logger.info("password is 'password'")
+
 def main():
     description = f"{banner}"
     parser = argparse.ArgumentParser(add_help=True, description=color(description, fore='deepskyblue'), formatter_class=argparse.RawDescriptionHelpFormatter)
@@ -180,6 +185,11 @@ def main():
     download_apps_intune_parser.add_argument('-m', '--mdmpfx', required=True, action='store', help='mdm pfx path')
     download_apps_intune_parser.add_argument('-d', '--device_name', required=True, action='store', help='device name')
 
+    pem2pfx_parser = subparsers.add_parser('pem2pfx', help='convert pem and key to pfx')
+    pem2pfx_parser.add_argument('-c', '--certpem', required=True, action='store', help='certificate pem file')
+    pem2pfx_parser.add_argument('-k', '--keypem', required=True, action='store', help='private key file')
+    pem2pfx_parser.add_argument('-o', '--output', required=True, action='store', help='output pfx path')
+
     args = parser.parse_args()
     proxy = None
     if args.proxy:
@@ -207,6 +217,8 @@ def main():
         pytune.download_apps(args.device_name, args.mdmpfx, proxy)
     if args.command == 'get_remediations':
         pytune.download_remediation_scripts(args.device_name, args.mdmpfx, proxy)
+    if args.command == 'pem2pfx':
+        pytune.pem2pfx(args.certpem, args.keypem, args.output)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- add helper to convert PEM certificate and key to password-protected PFX
- expose new command `pem2pfx`
- document usage and new command in README
- bump version to 1.2

## Testing
- `python3 -m py_compile pytune.py device/*.py utils/*.py`
- `python3 pytune.py -h`

------
https://chatgpt.com/codex/tasks/task_e_68421347a1c4832a96b3e60cb7e42f88